### PR TITLE
Fix an issue where json.dumps isn't handling callable values in dict

### DIFF
--- a/sibislogger.py
+++ b/sibislogger.py
@@ -14,6 +14,17 @@ import post_issues_to_github as pig
 #logging.getLogger("urllib3").setLevel(logging.WARNING)
 #logging.getLogger("requests").setLevel(logging.WARNING)
 
+class sibisJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        try:
+            return json.JSONEncoder.default(self, obj)
+        except TypeError as e:
+            if hasattr(obj, '__call__') and hasattr(obj, '__name__'):
+                return obj.__name__
+            raise e
+            
+
+
 class sibisLogging():
     """
     SIBIS Logging Module
@@ -41,7 +52,7 @@ class sibisLogging():
         self.log.update(experiment_site_id=uid,
                         error=message)
         self.log.update(kwargs)
-        jlog = json.dumps(self.log)
+        jlog = json.dumps(self.log, cls=sibisJSONEncoder)
         self.log.clear()
         return jlog
         

--- a/tests/test_sibislogger.py
+++ b/tests/test_sibislogger.py
@@ -105,3 +105,23 @@ log.takeTimer1()
 print "Output of time log written to "  + log.fileTime 
 
 # log.info('Unit Test (testing)', 'sibislogger_test_2 (TESTING)',"Testing 2", msg="Please ignore message")
+
+def some_function():
+  pass
+
+try:
+  slog.info('sibislogger_test_3', "Logging kwargs ",
+                        funkey = some_function,
+                        strkey = "some string",
+                        intkey = int(20),
+                        floatkey = float(12.12345678),
+                        listintkey = [ int(0), int(1), int(2), int(3) ],
+                        liststrkey = [ "a", "b", "c" ],
+                        listfloatkey = [ float(0.1), float(1.0), float(2.12345678) ],
+                        objkey = { 
+                          "strkey": "strval",
+                          "intkey": int(9),
+                          "floatkey":  float(9.87654321)
+                        })
+except Exception as e:
+  print("ERROR: failed to log kwargs", str(e))


### PR DESCRIPTION
Reported by @kipohl and @shippy:

```
Traceback (most recent call last):
  File "/sibis-software/ncanda-data-integration/scripts/import/laptops/harvester", line 347, in <module>
    if not session.run_svn('update', callbackNotifyFct = notify) : 
  File "/sibis-software/python-packages/sibispy/session.py", line 1028, in run_svn
    err_msg = str(e))
  File "/sibis-software/python-packages/sibispy/sibislogger.py", line 192, in info
    return log.info(uid,message,**kwargs)
  File "/sibis-software/python-packages/sibispy/sibislogger.py", line 53, in info
    jlog = self.create_log(uid, message, **kwargs)
  File "/sibis-software/python-packages/sibispy/sibislogger.py", line 44, in create_log
    jlog = json.dumps(self.log)
  File "/usr/local/lib/python2.7/json/__init__.py", line 244, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <function notify at 0x7f8f89053320> is not JSON serializable
```

Root problem was that kwargs with a value that was callable is not JSON serializable.  Added a custom JSONSerializer that handles this case and returns the `obj.__name__` as the JSON value.