### PR TITLE
disable verbose downloads from xnat

### DIFF
--- a/tests/test_xnat_util.py
+++ b/tests/test_xnat_util.py
@@ -171,7 +171,7 @@ def test_download_upload_file(xnat_util, xnat_test_data, workdir):
 
     # Download file 
     download_file = old_div(workdir.workspace, 'downloaded_') + test_data['file_name']
-    updated_file.download(download_file)
+    updated_file.download(download_file, verbose=False)
     assert download_file.exists(), "File should have downloaded"
 
     # Make sure uploaded and downloaded files are the same

--- a/xnat_util.py
+++ b/xnat_util.py
@@ -349,7 +349,7 @@ class XnatUtil(object):
 
         return response.content
   
-  def download_file(self, experiment_id, resource_id, file_id, target_file, format=None, verbose=True, timeout=None):
+  def download_file(self, experiment_id, resource_id, file_id, target_file, format=None, verbose=False, timeout=None):
     filesRef = self._xnat.experiments[experiment_id].resources[resource_id].files
     fileData = filesRef[file_id]
     target_dir = os.path.dirname(target_file)


### PR DESCRIPTION
Disabled verbose downloads when using xnatpy api.  Verbose downloading is the default.

Tested on sibis and sibis-storage by passing `run_all_tests` in `sibispy`.