### PR TITLE
Introduce a generic bulk-marking logic + its specialization on form status

### DIFF
--- a/bulk_operations.py
+++ b/bulk_operations.py
@@ -13,7 +13,8 @@ def bulk_mark(redcap_api: rc.Project, field_name: Union[List, str],
     """
     Workhorse bulk-marking function.
 
-    NOTE: Could probably be moved to sibispy utils for reuse.
+    If applied to repeating instruments, `records_df` must already have valid
+    `redcap_repeat_instrument` and `redcap_repeat_instance`.
     """
     upload = records_df.copy(deep=True)
 
@@ -81,6 +82,9 @@ def read_targets(redcap_api, from_file):
     if redcap_api.is_longitudinal():
         assert 'redcap_event_name' in targets.columns
         out_cols.append('redcap_event_name')
+
+    if 'redcap_repeat_instrument' in targets.columns:
+        out_cols.extend(['redcap_repeat_instrument', 'redcap_repeat_instance'])
 
     # If the file contains any other columns, strip them - don't want to add
     # them to the later upload

--- a/bulk_operations.py
+++ b/bulk_operations.py
@@ -1,0 +1,126 @@
+"""
+Generalized mechanism for mass-setting a FIELD to a particular VALUE.
+"""
+import pandas as pd
+import redcap as rc
+from six import string_types
+from typing import Union, List, Dict
+
+
+def bulk_mark(redcap_api: rc.Project, field_name: Union[List, str],
+              value: str, records_df: pd.DataFrame, 
+              upload_individually: bool = False) -> Dict:
+    """
+    Workhorse bulk-marking function.
+
+    NOTE: Could probably be moved to sibispy utils for reuse.
+    """
+    upload = records_df.copy(deep=True)
+
+    # upload.loc[:, field_name] = value
+    if isinstance(field_name, string_types):
+        assignments = {field_name: value}
+    else:
+        assignments = dict(zip(field_name, [value] * len(field_name)))
+
+    # Might need to create multiple new columns with the same value, which
+    # cannot be done with bare .loc if the columns don't already exist. This is
+    # the simplest way to do it quickly. (If field_name is str, then this is
+    # equivalent to upload.assign(field_name=value).)
+    upload = upload.assign(**assignments)
+
+    # TODO: Should probably wrap this in a try block, since we're not even
+    # checking existence of variables and not uploading records one at a time?
+    if upload_individually:
+        outcomes = []
+        for idx, _ in upload.iterrows():
+            outcome = redcap_api.import_records(upload.loc[[idx]])
+            outcomes.append(outcome)
+    else:
+        outcomes = redcap_api.import_records(upload)
+    
+    return outcomes
+
+
+def get_status_fields_for_form(redcap_api, form_name):
+    """
+    Return completeness and (if available) missingness field names in a form.
+
+    If form_name doesn't exist in the project data dictionary, raise NameError.
+
+    Returns a dict with 'completeness' and 'missingness' keys.
+    """
+    datadict = redcap_api.export_metadata(format='df').reset_index()
+    form_datadict = datadict.loc[datadict['form_name'] == form_name, :]
+    if form_datadict.empty:
+        raise NameError('{}: No such form in selected API!'.format(form_name))
+
+    field_names = {'completeness': form_name + '_complete'}
+
+    missing_field_name = form_datadict.loc[
+            form_datadict['field_name'].str.endswith('_missing'),
+            'field_name']  # FIXME: What type does this return?
+    # TODO: Throw error if multiple fields are found?
+    try:
+        field_names.update({'missingness': missing_field_name.item()})
+    except ValueError:  # no value available
+        pass
+
+    return field_names
+
+
+def read_targets(redcap_api, from_file):
+    """
+    Convert file to a columnless DataFrame indexed by Redcap primary keys.
+
+    If primary keys for the project are not present, raises AssertionError.
+    """
+    targets = pd.read_csv(from_file)
+    out_cols = [redcap_api.def_field]
+    assert redcap_api.def_field in targets.columns
+    if redcap_api.is_longitudinal():
+        assert 'redcap_event_name' in targets.columns
+        out_cols.append('redcap_event_name')
+
+    # If the file contains any other columns, strip them - don't want to add
+    # them to the later upload
+    targets = targets[out_cols].drop_duplicates()
+
+    # Return a DataFrame with *only* appropriate indexing. This is necessary
+    # for redcap.Project.import_records() to work properly once the variable of
+    # interest is set for the DataFrame.
+    #
+    # (If multiple Redcap primary keys are standard columns, the MultiIndex is
+    # wrongly assigned by .import_records() and the upload fails.)
+
+    targets.set_index(out_cols, inplace=True)
+    return targets
+
+
+def bulk_mark_status(redcap_api, form_name, missingness, completeness,
+        records_df, verbose=False):
+    """
+    Courtesy function to bulk-mark completeness and missingness.
+    
+    Returns a tuple of import outcomes for completeness and missingness upload,
+    respectively.
+
+    Relies on argparse to provide valid completness and missingness values.
+    """
+    field_names = get_status_fields_for_form(redcap_api, form_name)
+    comp_results = None
+    miss_results = None
+
+    # In either case, only set the status if it has been passed
+    if completeness is not None:
+        comp_results = bulk_mark(redcap_api, field_names['completeness'],
+                completeness, records_df)
+
+    if missingness is not None:
+        if not field_names.get('missingness'):
+            raise TypeError('Missingness cannot be set for selected form!')
+        else:
+            miss_results = bulk_mark(redcap_api, field_names['missingness'],
+                    missingness, records_df)
+
+    return (comp_results, miss_results)

--- a/bulk_operations.py
+++ b/bulk_operations.py
@@ -77,12 +77,13 @@ def read_targets(redcap_api, from_file):
     If primary keys for the project are not present, raises AssertionError.
     """
     targets = pd.read_csv(from_file)
-    out_cols = [redcap_api.def_field]
+    index_cols = [redcap_api.def_field]
     assert redcap_api.def_field in targets.columns
     if redcap_api.is_longitudinal():
         assert 'redcap_event_name' in targets.columns
-        out_cols.append('redcap_event_name')
+        index_cols.append('redcap_event_name')
 
+    out_cols = index_cols.copy()
     if 'redcap_repeat_instrument' in targets.columns:
         out_cols.extend(['redcap_repeat_instrument', 'redcap_repeat_instance'])
 
@@ -97,7 +98,7 @@ def read_targets(redcap_api, from_file):
     # (If multiple Redcap primary keys are standard columns, the MultiIndex is
     # wrongly assigned by .import_records() and the upload fails.)
 
-    targets.set_index(out_cols, inplace=True)
+    targets.set_index(index_cols, inplace=True)
     return targets
 
 

--- a/cmds/bulk_mark.py
+++ b/cmds/bulk_mark.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+
+"""
+Generalized mechanism for mass-setting a FIELD to a particular VALUE.
+
+The CLI interface provides two APIs:
+
+1. direct: For specified subjects within a given event, set FIELD to VALUE.
+
+2. status: For the specific case of setting completeness and missignness, find
+    those fields within the form and set them to the value, if specified.
+
+"""
+
+import argparse
+import pandas as pd
+import sys
+import sibispy
+from sibispy import sibislogger as slog
+
+
+def parse_args(args=None):
+    """
+    Expose two APIs: direct/explicit for arbitrary field/value combinations,
+    and status-based for completeness/missingness setting that infers variable
+    names based on provided form name.
+
+    args can be provided as a list of CLI items, e.g. ['-v', '--api',
+    'data_entry']. This is useful for isolated testing.
+
+    If args is None, argparse.parse_args(None) will automatically use sys.argv.
+    """
+    parser = argparse.ArgumentParser(description="",
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    # Shared arguments
+    parser.add_argument('--from-file',
+            help="File with subject (and event) identifiers")
+    parser.add_argument('--api',
+            required=True,
+            choices=['data_entry', 'import_laptops'],
+            help="Name of sibispy-configured API to use.")
+    parser.add_argument("-v", "--verbose",
+            help="Verbose operation",
+            action="store_true")
+
+    # Two approaches to bulk setting
+    subparsers = parser.add_subparsers(help="Bulk-setting method", 
+            # Ensure that the used subparser is available in args.command
+            dest='command')
+
+    # 1. Define status and form to apply, let the command figure out field name and value
+    status = subparsers.add_parser('status',
+            help="Set missingness / completeneses status for a given form")
+    status.add_argument('--form', required=True,
+            help="Form to apply the status arguments to")
+
+    completeness_status = status.add_mutually_exclusive_group()
+    completeness_status.add_argument('--incomplete',
+            dest='completeness', const=0, action='store_const')
+    completeness_status.add_argument('--unverified',
+            dest='completeness', const=1, action='store_const')
+    completeness_status.add_argument('--complete',
+            dest='completeness', const=2, action='store_const')
+
+    missingness_status = status.add_mutually_exclusive_group()
+    missingness_status.add_argument('--missing',
+            dest='missingness', const=1, action='store_const')
+    missingness_status.add_argument('--present', '--not-missing',
+            dest='missingness', const=0, action='store_const')
+
+    # 2. Specify explicitly field name and value, set that
+    direct = subparsers.add_parser('direct',
+            help="Manually specify field name and value")
+    direct.add_argument('--field', '--field-name',
+            help="Name of field to set")
+    direct.add_argument('--value',
+            help="Value to set in field")
+
+    return parser.parse_args(args)
+
+
+def bulk_mark(redcap_api, field_name, value, records_df):
+    """
+    Workhorse bulk-marking function.
+
+    NOTE: Could probably be moved to sibispy utils for reuse.
+    """
+    upload = records_df.copy(deep=True)
+    upload[field_name] = value
+    # TODO: Should probably wrap this in a try block, since we're not even
+    # checking existence of variables?
+    outcome = redcap_api.import_records(upload)
+    
+    return outcome
+
+
+def get_status_fields_for_form(redcap_api, form_name):
+    """
+    Return completeness and (if available) missingness field names in a form.
+
+    If form_name doesn't exist in the project data dictionary, raise NameError.
+
+    Returns a dict with 'completeness' and 'missingness' keys.
+    """
+    datadict = redcap_api.export_metadata(format='df').reset_index()
+    form_datadict = datadict.loc[datadict['form_name'] == form_name, :]
+    if form_datadict.empty:
+        raise NameError('{}: No such form in selected API!'.format(form_name))
+
+    field_names = {'completeness': form_name + '_complete'}
+
+    missing_field_name = form_datadict.loc[
+            form_datadict['field_name'].str.endswith('_missing'),
+            'field_name']  # FIXME: What type does this return?
+    # TODO: Throw error if multiple fields are found?
+    try:
+        field_names.update({'missingness': missing_field_name.item()})
+    except ValueError:  # no value available
+        pass
+    
+    return field_names
+
+
+def read_targets(redcap_api, from_file):
+    """
+    Convert file to a columnless DataFrame indexed by Redcap primary keys.
+
+    If primary keys for the project are not present, raises AssertionError.
+    """
+    targets = pd.read_csv(from_file)
+    out_cols = [redcap_api.def_field]
+    assert redcap_api.def_field in targets.columns
+    if redcap_api.is_longitudinal():
+        assert 'redcap_event_name' in targets.columns
+        out_cols.append('redcap_event_name')
+
+    # If the file contains any other columns, strip them - don't want to add
+    # them to the later upload
+    targets = targets[out_cols]
+
+    # Return a DataFrame with *only* appropriate indexing. This is necessary
+    # for redcap.Project.import_records() to work properly once the variable of
+    # interest is set for the DataFrame.
+    #
+    # (If multiple Redcap primary keys are standard columns, the MultiIndex is
+    # wrongly assigned by .import_records() and the upload fails.)
+
+    targets.set_index(out_cols, inplace=True)
+    return targets
+
+
+def bulk_mark_status(redcap_api, form_name, missingness, completeness,
+        records_df, verbose=False):
+    """
+    Courtesy function to bulk-mark completeness and missingness. 
+    
+    Returns a tuple of import outcomes for completeness and missingness upload,
+    respectively.
+
+    Relies on argparse to provide valid completness and missingness values.
+    """
+    field_names = get_status_fields_for_form(redcap_api, form_name)
+    comp_results = None
+    miss_results = None
+
+    # In either case, only set the status if it has been passed
+    if completeness:
+        comp_results = bulk_mark(redcap_api, field_names['completeness'],
+                completeness, records_df)
+
+    if missingness:
+        if not field_names.get('missingness'):
+            raise TypeError('Missingness cannot be set for selected form!')
+        else:
+            miss_results = bulk_mark(redcap_api, field_names['missingness'],
+                    missingness, records_df)
+
+    return (comp_results, miss_results)
+
+
+if __name__ == '__main__':
+    # Set up the environment
+    args = parse_args()
+    if not args.command:
+        sys.exit('You must specify "direct" or "status" handler!')
+    else:
+        slog.init_log(args.verbose, None, 'bulk_mark', 'bulk_mark', None)
+        session = sibispy.Session()
+        if not session.configure():
+            sys.exit("Error: session configure file was not found")
+
+        api = session.connect_server(args.api, True)
+        targets = read_targets(api, args.from_file)
+
+    # Based on selected handler, set the value
+    if args.command == 'direct':
+        if args.verbose:
+            print('Setting {field} to {value} in {api}'.format(**vars(args)))
+        results = bulk_mark(api, args.field_name, args.value, targets)
+        # TODO: Process results
+
+    elif args.command == 'status':
+        if args.missingness is None and args.completeness is None:
+            sys.exit('One or both of missingness and completeness must be set!')
+        else:
+            if args.verbose:
+                print(('Setting missingness to {missingness} and completion to'
+                       ' {completeness} in {form}').format(**vars(args)))
+            complete_results, missing_results = bulk_mark_status(api,
+                    form_name=args.form, missingness=args.missingness,
+                    completeness=args.completeness, records_df=targets)
+            # TODO: Process results - the outcome is a dict with 'count' and
+            # possibly 'error' keys

--- a/cmds/bulk_mark.py
+++ b/cmds/bulk_mark.py
@@ -2,7 +2,7 @@
 
 """
 The CLI interface to the generalized mechanism for mass-setting a FIELD to 
-a particular VALUE.
+a particular VALUE **on non-repeating instruments** [1].
 
 Two interfaces are provided:
 
@@ -11,6 +11,9 @@ Two interfaces are provided:
 2. status: For the specific case of setting completeness and missignness, find
     those fields within the form and set them to the value, if specified.
 
+[1] In principle, if redcap_repeat_instance and redcap_repeat_instrument are
+    provided in the targets file, then this should still work - but it has yet
+    to be tested that way.
 """
 
 import argparse
@@ -21,6 +24,7 @@ from sibispy import sibislogger as slog
 from sibispy.bulk_operations import (
     bulk_mark, get_status_fields_for_form, bulk_mark_status, read_targets)
 import pdb 
+
 
 def parse_args(args=None):
     """

--- a/cmds/bulk_mark.py
+++ b/cmds/bulk_mark.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 """
-The CLI interface to the generalized mechanism for mass-setting a FIELD to 
-a particular VALUE **on non-repeating instruments** [1].
+The CLI interface to the generalized mechanism for mass-setting a FIELD
+to a particular VALUE on **either** repeeating **or** non-repeating
+instruments [1].
 
 Two interfaces are provided:
 
@@ -11,9 +12,9 @@ Two interfaces are provided:
 2. status: For the specific case of setting completeness and missignness, find
     those fields within the form and set them to the value, if specified.
 
-[1] In principle, if redcap_repeat_instance and redcap_repeat_instrument are
-    provided in the targets file, then this should still work - but it has yet
-    to be tested that way.
+[1] This is because it's impossible to mix targets for repeating and
+non-repeating instruments, because the value is applied to all rows, and
+repeating/non-repeating variables have to be filled on separate ones.
 """
 
 import argparse

--- a/cmds/bulk_mark.py
+++ b/cmds/bulk_mark.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
 """
-Generalized mechanism for mass-setting a FIELD to a particular VALUE.
+The CLI interface to the generalized mechanism for mass-setting a FIELD to 
+a particular VALUE.
 
-The CLI interface provides two APIs:
+Two interfaces are provided:
 
 1. direct: For specified subjects within a given event, set FIELD to VALUE.
 
@@ -17,7 +18,9 @@ import pandas as pd
 import sys
 import sibispy
 from sibispy import sibislogger as slog
-
+from sibispy.bulk_operations import (
+    bulk_mark, get_status_fields_for_form, bulk_mark_status, read_targets)
+import pdb 
 
 def parse_args(args=None):
     """
@@ -30,8 +33,9 @@ def parse_args(args=None):
 
     If args is None, argparse.parse_args(None) will automatically use sys.argv.
     """
-    parser = argparse.ArgumentParser(description="",
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        usage=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     # Shared arguments
     parser.add_argument('--from-file',
@@ -78,105 +82,6 @@ def parse_args(args=None):
             help="Value to set in field")
 
     return parser.parse_args(args)
-
-
-def bulk_mark(redcap_api, field_name, value, records_df):
-    """
-    Workhorse bulk-marking function.
-
-    NOTE: Could probably be moved to sibispy utils for reuse.
-    """
-    upload = records_df.copy(deep=True)
-    upload[field_name] = value
-    # TODO: Should probably wrap this in a try block, since we're not even
-    # checking existence of variables and not uploading records one at a time?
-    outcome = redcap_api.import_records(upload)
-    
-    return outcome
-
-
-def get_status_fields_for_form(redcap_api, form_name):
-    """
-    Return completeness and (if available) missingness field names in a form.
-
-    If form_name doesn't exist in the project data dictionary, raise NameError.
-
-    Returns a dict with 'completeness' and 'missingness' keys.
-    """
-    datadict = redcap_api.export_metadata(format='df').reset_index()
-    form_datadict = datadict.loc[datadict['form_name'] == form_name, :]
-    if form_datadict.empty:
-        raise NameError('{}: No such form in selected API!'.format(form_name))
-
-    field_names = {'completeness': form_name + '_complete'}
-
-    missing_field_name = form_datadict.loc[
-            form_datadict['field_name'].str.endswith('_missing'),
-            'field_name']  # FIXME: What type does this return?
-    # TODO: Throw error if multiple fields are found?
-    try:
-        field_names.update({'missingness': missing_field_name.item()})
-    except ValueError:  # no value available
-        pass
-    
-    return field_names
-
-
-def read_targets(redcap_api, from_file):
-    """
-    Convert file to a columnless DataFrame indexed by Redcap primary keys.
-
-    If primary keys for the project are not present, raises AssertionError.
-    """
-    targets = pd.read_csv(from_file)
-    out_cols = [redcap_api.def_field]
-    assert redcap_api.def_field in targets.columns
-    if redcap_api.is_longitudinal():
-        assert 'redcap_event_name' in targets.columns
-        out_cols.append('redcap_event_name')
-
-    # If the file contains any other columns, strip them - don't want to add
-    # them to the later upload
-    targets = targets[out_cols].drop_duplicates()
-
-    # Return a DataFrame with *only* appropriate indexing. This is necessary
-    # for redcap.Project.import_records() to work properly once the variable of
-    # interest is set for the DataFrame.
-    #
-    # (If multiple Redcap primary keys are standard columns, the MultiIndex is
-    # wrongly assigned by .import_records() and the upload fails.)
-
-    targets.set_index(out_cols, inplace=True)
-    return targets
-
-
-def bulk_mark_status(redcap_api, form_name, missingness, completeness,
-        records_df, verbose=False):
-    """
-    Courtesy function to bulk-mark completeness and missingness. 
-    
-    Returns a tuple of import outcomes for completeness and missingness upload,
-    respectively.
-
-    Relies on argparse to provide valid completness and missingness values.
-    """
-    field_names = get_status_fields_for_form(redcap_api, form_name)
-    comp_results = None
-    miss_results = None
-
-    # In either case, only set the status if it has been passed
-    if completeness is not None:
-        comp_results = bulk_mark(redcap_api, field_names['completeness'],
-                completeness, records_df)
-
-    if missingness is not None:
-        if not field_names.get('missingness'):
-            raise TypeError('Missingness cannot be set for selected form!')
-        else:
-            miss_results = bulk_mark(redcap_api, field_names['missingness'],
-                    missingness, records_df)
-
-    return (comp_results, miss_results)
 
 
 if __name__ == '__main__':

--- a/cmds/bulk_mark.py
+++ b/cmds/bulk_mark.py
@@ -46,7 +46,6 @@ def parse_args(args=None):
             help="File with subject (and event) identifiers")
     parser.add_argument('--api',
             required=True,
-            choices=['data_entry', 'import_laptops'],
             help="Name of sibispy-configured API to use.")
     parser.add_argument("-v", "--verbose",
             help="Verbose operation",
@@ -95,7 +94,7 @@ if __name__ == '__main__':
         sys.exit('You must specify "direct" or "status" handler!')
     else:
         slog.init_log(args.verbose, None, 'bulk_mark', 'bulk_mark', None)
-        session = sibispy.Session()
+        session = sibispy.Session(opt_api={args.api: None})
         if not session.configure():
             sys.exit("Error: session configure file was not found")
 

--- a/cmds/recompute_autocalc.py
+++ b/cmds/recompute_autocalc.py
@@ -160,12 +160,6 @@ def main():
                                   format='df')
                .dropna(axis=1, how='all'))
 
-    if 'redcap_repeat_instance' in targets.columns:
-        # i.e. redcap_repeat_instance wasn't full of NaNs and dropped, so
-        # some repeating data is involved
-        raise KeyError("Repeating-form metadata present in retrieved targets. "
-                       "Please only select non-repeating forms.")
-
     # FIXME: Doesn't handle repeating forms correctly. To do that, need to:
     #
     # 1. determine which forms have a trash field to be set

--- a/cmds/recompute_autocalc.py
+++ b/cmds/recompute_autocalc.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""
+Upload random values in order to force Redcap calculations to update.
+"""
+import argparse
+import pdb
+import sibispy
+from sibispy import sibislogger as slog
+from sibispy import bulk_operations as bulk
+import random
+import redcap as rc
+from typing import Union, List, Dict
+
+"""
+NOTE: At this point, the script will set a random value on all records in the
+Redcap project, **regardless of whether there's any data on the form for that
+particular subject.**
+
+NOTE: for some versions of Redcap (pre-8.10.3 and pre-9.0.0), a "bug" means
+that a single edit anywhere on the event will recalculate all variables
+therein:
+https://community.projectredcap.org/questions/55192/when-are-calculated-fields-saved.html
+
+From testing on 8.7.1, it also seems that any event where a calculation is
+triggered will trigger recalculations on all events, which means we might get
+away with doing this just on visit_notes - since all events calculate `age`.
+
+For those cases, we can get by with a certain economy of updates.
+"""
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(
+        # usage=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    form_options = parser.add_mutually_exclusive_group()
+    form_options.add_argument('--all-forms', action="store_true")
+    form_options.add_argument('--forms', nargs='*',
+                              help="Forms to refresh")
+
+    parser.add_argument('-e', '--events', nargs='*', default=None,
+                        help="Limit auto-generation to listed events")
+    parser.add_argument('-T', '--template', default='{form}_update_aux_',
+                        help="Template for inferring variable name from form")
+    parser.add_argument("-v", "--verbose",
+                        help="Verbose operation",
+                        action="store_true")
+    parser.add_argument('--api',
+                        required=True,
+                        help="Name of sibispy-configured API to use.")
+    return parser.parse_args()
+
+
+def _get_variable_names(api: rc.Project, forms: List, template: str,
+                        verbose=False) -> List:
+    varnames = [template.format(form=x) for x in forms]
+    actual_varnames = [x for x in varnames if x in api.field_names]
+    dropped_varnames = [x for x in varnames if x not in actual_varnames]
+    if verbose:
+        print("Setting random value on the following variables: "
+              F"{actual_varnames}")
+        if len(dropped_varnames) > 0:  # and not args.all_forms:
+            print("The following variables don't exist in target API: "
+                  F"{dropped_varnames}")
+    return actual_varnames
+
+
+def _get_valid_forms(api: rc.Project, forms: List, template: str) -> List:
+    """
+    Filter down passed forms based on their presence in the project + presence
+    """
+    valid_forms = []
+    for form in forms:
+        if form not in api.forms:
+            continue
+        elif template.format(form=form) not in api.field_names:
+            continue
+        else:
+            valid_forms.append(form)
+
+    return valid_forms
+
+
+def main():
+    args = parse_args()
+    slog.init_log(verbose=args.verbose,
+                  post_to_github=False,
+                  github_issue_title='Recomputing Redcap auto-calculations',
+                  github_issue_label='bug',  # recompute_autocalc
+                  timerDir=None)
+    session = sibispy.Session(opt_api={args.api: None})
+    if not session.configure():
+        return None
+    api = session.connect_server(args.api)
+    if api is None:
+        raise KeyError("Invalid API name {}!".format(args.api))
+
+    if args.all_forms:
+        forms = _get_valid_forms(api, api.forms, args.template)
+    else:
+        forms = _get_valid_forms(api, args.forms, args.template)
+
+    # Filter down to only valid variable names
+    varnames = _get_variable_names(api, forms, args.template, args.verbose)
+
+    # Redcap needs an actual change -> generate a new random number every time
+    random_value = random.randint(10**6, 10**7)
+    targets = (api.export_records(fields=[api.def_field],
+                                  events=args.events,
+                                  format='df')
+               .dropna(axis=1, how='all'))
+    # FIXME: Doesn't handle repeating forms correctly. To do that, need to:
+    #
+    # 1. determine which forms have a trash field to be set
+    # 2. export the _complete field for each form
+    # 3. split up the delivered results by NA-ness of redcap_repeat_instance
+    # 4. if redcap_repeat_instance.notnull(),
+    # 5. proceed from there
+
+    # NOTE: `upload_individually` here is necessary, or at least uploading in
+    # small batches - from testing on 8.7.1, we found that if a Redcap upload
+    # is sufficiently large, the auto-calculation will not happen.
+    result = bulk.bulk_mark(api, varnames, random_value, targets,
+                            upload_individually=True)
+    print(result)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Logic for bulk-changing Redcap fields in general, and changing form statuses (completeness and missingness in particular).

CLI contains two subcommands:

- If `direct` is the subcommand, `bulk_mark.py` will set the passed `--field-name` to the passed `--value`.
- If `status` is the subcommand, `bulk_mark.py` will look up the status fields for the passed `--form` and then set them to the required value - `--missing` / `--present` (for missingness) and `--incomplete` / `--unverified` / `--complete`.

The only way to determine which participants will be affected is through a target file, whose path goes into `--from-file`. This file has to have the Redcap primary key (`redcap.Project.def_field`) and, if the Redcap project is longitudinal, `redcap_event_name`. `bulk_mark` will use every participant contained in the field.

`--from-file` and `--api` must be set prior to the subcommand.

Example calls:

```bash
TARGET_FILE=/tmp/ncanda_skips.csv
./bulk_mark.py -v --api data_entry --from-file "$TARGET_FILE" direct --field visit_ignore___yes --value 1
./bulk_mark.py -v --api data_entry --from-file "$TARGET_FILE" direct --field visit_ignore_why --value SKIP
./bulk_mark.py -v --api data_entry --from-file "$TARGET_FILE" status --form visit_date --complete
```