### PR TITLE
Generalize some demographics capabilities when computing summary scores

### DIFF
--- a/summary_scores_util.py
+++ b/summary_scores_util.py
@@ -1,0 +1,36 @@
+import os, glob, stat, sys, imp
+
+class SummaryScoresCollector():
+  def __init__(self, module_init_script):
+
+    self.fields_list = dict()
+    self.functions = dict()
+    self.output_form = dict()
+    self.instrument_list = []
+
+    module_dir = os.path.dirname(os.path.abspath(module_init_script))
+
+    instruments = [ os.path.basename( d ) for d in glob.glob(os.path.join(module_dir,'*')) if stat.S_ISDIR( os.stat( d ).st_mode ) and os.path.exists( os.path.join( d, '__init__.py' ) ) ]
+
+    sys.path.append( os.path.abspath(os.path.dirname(module_init_script) ) )
+
+    for i in instruments:
+      module_found = imp.find_module( i, [module_dir] )
+      module = imp.load_module( i, module_found[0], module_found[1], module_found[2] )
+
+      self.instrument_list.append( i )
+      self.fields_list[i] =  module.input_fields
+      self.functions[i] = module.compute_scores
+      self.output_form[i] = module.output_form
+
+  # dataframe and errorFlag
+  def compute_scores(self, instrument, input_data, demographics):
+    scoresDF = self.functions[instrument](input_data, demographics) 
+    
+    # remove nan entries as they corrupt data ingest (REDCAP cannot handle it correctly) and superfluous zeros
+    # this gave an error as it only works for float values to replace
+    if len(scoresDF) :
+      # Only execute it not empty 
+      return (scoresDF.astype(object).fillna(''), False)   
+      
+    return (scoresDF, False)

--- a/tests/test_summary_scores_util.py
+++ b/tests/test_summary_scores_util.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import pytest
+import sibispy
+from sibispy.summary_scores_util import SummaryScoresCollector
+from sibispy import sibislogger as slog
+
+from .utils import get_session, get_test_config
+
+@pytest.fixture
+def session(config_file):
+    return get_session(config_file)
+
+@pytest.fixture
+def xnat_test_data(session):
+  return get_test_config('test_summary_scores_util', session)
+
+
+def test_collect_summary_scores(xnat_test_data):
+  collector = SummaryScoresCollector(xnat_test_data['scoring_script_dir'])


### PR DESCRIPTION
Make demographic variables configurable via sibis_sys_config.yml such that summary score computation that utilizes demographics can be generalized across projects.

This functionality has been tested via just use... I believe several are using this addition already to compute summary scores in development.

#38 is dependent upon this being merged.