### PR TITLE
should be an minor bug fix to prevent pyyaml warning

### DIFF
--- a/config_file_parser.py
+++ b/config_file_parser.py
@@ -63,7 +63,7 @@ class config_file_parser(object):
                 if ordered_load:
                     self.__config_dict = __ordered_load__(fi, yaml.SafeLoader)
                 else : 
-                    self.__config_dict = yaml.load(fi)
+                    self.__config_dict = yaml.safe_load(fi)
 
         except IOError as err:
             return err


### PR DESCRIPTION
`yaml.load()` is being deprecated because it's unsafe.  Changed our usage to utilize the `yaml.safe_load()` instead.  I don't believe we are using any of the `dynamic code evaluation features` that exist in `yaml.load()` which allowed you to embed raw python in the yaml file which would get executed and evaluated upon file load.  It's a dangerous feature anyways that we shouldn't use.  If we did need something like this we should consider adopting a plugin architecture instead.

This has only been tested locally using the `hivalc-data-integration` `export_measures.py` script.  Pyyaml no longer raises a deprecation warning.