### PR TITLE
Fail gracefully if redcap_event_name cannot be looked up in Redcap error

### DIFF
--- a/session.py
+++ b/session.py
@@ -880,12 +880,20 @@ class Session(object):
                     
                 if len(err_list) > 3 and "This field is located on a form that is locked. You must first unlock this form for this record." in err_list[3]:
                     red_var = err_list[1]
+
                     try:
                         event = err_list[0].split('(')[1][:-1]
                     except IndexError:  # Try to obtain event from record if unextractable from error
                         event = record.get('redcap_event_name')
+
+                    # NOTE: event must be List[str] or None, but cannot by
+                    # List[NoneType] or str by itself, so we need to ensure
+                    # it's a list depending on circumstance
+                    if event is not None:
+                        event = [event]
+
                     if subject_label: 
-                        red_value_temp = self.redcap_export_records(False,fields=[red_var],records=[subject_label],events=[event])
+                        red_value_temp = self.redcap_export_records(False,fields=[red_var],records=[subject_label],events=event)
                         if red_value_temp : 
                             red_value = red_value_temp[0][red_var]
                             if "mri_xnat_sid" not in record or "mri_xnat_eids" not in record :

--- a/session.py
+++ b/session.py
@@ -901,9 +901,9 @@ class Session(object):
                             red_value = red_value_temp[0][red_var]
                             if "mri_xnat_sid" not in record or "mri_xnat_eids" not in record :
                                 slog.info(error_label, error,
-                                  redcap_value="'"+str(red_value)+"'",
                                   redcap_variable=red_var,
                                   redcap_event=event,
+                                  redcap_value="'"+str(red_value)+"'",
                                   new_value="'"+str(err_list[2])+"'",
                                   import_record_id=str(record_id), 
                                   requestError=str(e),


### PR DESCRIPTION
Fixes #45 and now-countless ncanda-operations issues. Sample failing call in an NCANDA `pipeline-back` container: `/sibis-software/python-packages/sibispy/cmds/redcap_update_summary_scores.py -s C-70123-F-0 -i ssaga_dsm4`

To test the fix, do `PYTHONPATH=/fs/ncanda-share/beta/simon/sibispy-hotfix;  /sibis-software/python-packages/sibispy/cmds/redcap_update_summary_scores.py -s C-70123-F-0 -i ssaga_dsm4`