### PR TITLE
Create a CLI helper

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,138 @@
+"""
+A number of argparse helpers, generally using custom argument typing for
+additional input value transformations.
+"""
+import argparse
+import re
+import sys
+from typing import List, Tuple, Union
+
+
+def add_standard_params(parser: argparse.ArgumentParser) -> None:
+    """
+    Adds -v, -p and -t.
+    """
+    parser.add_argument("-v", "--verbose",
+                        dest="verbose",
+                        help="Print debug info to stdout",
+                        action='store_true')
+    parser.add_argument("-p", "--post-to-github",
+                        help="Post all issues to GitHub instead of stdout",
+                        action="store_true")
+    parser.add_argument("-t", "--time-log-dir",
+                        help="If set, time logs are written to that directory",
+                        action="store", default=None)
+
+
+def add_event_param(
+        parser: argparse.ArgumentParser,
+        template: str = "{}y visit",
+        accepted_regex: str = r'^\d+$',
+        coerce: bool = True,
+        required: bool = False) -> None:
+    """
+    Handles and transforms arbitrarily entered events.
+    """
+
+    nargs = '+' if required else '*'
+
+    def __event_handler(arg: str) -> Union[str, None]:
+        if re.match(accepted_regex, arg):
+            return template.format(arg)
+        elif coerce:
+            return arg
+        else:
+            return None
+
+    parser.add_argument("-e", "--event",
+                        help=("Event name matching regex {}, before "
+                              "transformation to {}").format(accepted_regex,
+                                                             template),
+                        nargs=nargs,
+                        type=__event_handler)
+
+
+def add_subject_param(parser: argparse.ArgumentParser,
+                      required: bool = False,
+                      choices: List[str] = None) -> None:
+    """
+    Add parameter for subject ID entry.
+    """
+    nargs = '+' if required else '*'
+
+    parser.add_argument("-s", "--study-id", "--subject",
+                        help="Subject IDs that the script should affect",
+                        nargs=nargs,
+                        choices=choices,
+                        # metavar="STUDY_ID"
+                        action="store")
+
+
+def add_form_param(parser: argparse.ArgumentParser,
+                   eligible_forms: List[Tuple[str]] = [],
+                   raise_missing: bool = True,
+                   dest='forms',
+                   short_switch="-i") -> None:
+    """
+    Add the forms parameter, with checking for form aliases.
+
+    eligible_forms: a list of tuples, where the first element in the tuple is
+        the canonical name of the form, and the remaining are allowable names
+        for the form
+    short_switch: the "short" option - `-i` by default (short for instruments),
+        but some CLIs use -f to mean --forms instead of --force.
+    """
+    # _eligible_forms = []
+    # for x in eligible_forms:
+    #     if isinstance(x, string_types):
+    #         _eligible_forms.append((x))
+    #     else:
+    #         _eligible_forms.append(x)
+
+    def __form_handler(arg):
+        forms_found = [x for x in eligible_forms if arg in x]
+        if len(forms_found) == 1:
+            return forms_found[0][0]
+        elif not raise_missing:
+            return None
+        else:
+            if len(forms_found) == 0:
+                raise ValueError("{} not found in eligible forms {}"
+                                 .format(arg, eligible_forms))
+            elif len(forms_found) > 1:
+                raise ValueError("Ambiguous {}, found in following forms: {}"
+                                 .format(arg, forms_found))
+
+    parser.add_argument(short_switch, '--forms', '--form', '--instrument',
+                        dest=dest,
+                        nargs='*',
+                        help="Forms that the script should affect",
+                        type=__form_handler)
+
+
+def transform_commas_in_args(arg_list: List[str] = sys.argv[1:]) -> List[str]:
+    """
+    Essentially, turn comma splits into spaces.
+
+    Limited, in that it splices *any* commas, which might be actually valid
+    filename parts etc. Ideally, this would be part of an argparse.Action.
+    """
+    _arg_list = []
+    for x in arg_list:
+        if "," in x:
+            _arg_list.extend(x.split(","))
+        else:
+            _arg_list.append(x)
+    return _arg_list
+
+
+# if __name__ == '__main__':
+#     args = transform_commas_in_args(sys.argv[1:])
+#     parser = argparse.ArgumentParser()
+#     add_event_param(parser, template="visit_{}")
+#     add_subject_param(parser)
+#     add_form_param(parser, eligible_forms=[
+#         ('limesurvey_ssaga_youth', 'lssaga_youth', 'lssaga1_youth')
+#     ])
+#     add_standard_params(parser)
+#     print(parser.parse_args(args))

--- a/cli.py
+++ b/cli.py
@@ -26,10 +26,11 @@ def add_standard_params(parser: argparse.ArgumentParser) -> None:
 
 def add_event_param(
         parser: argparse.ArgumentParser,
+        dest: str = "event",
+        required: bool = False,
         template: str = "{}y visit",
         accepted_regex: str = r'^\d+$',
-        coerce: bool = True,
-        required: bool = False) -> None:
+        coerce: bool = True) -> None:
     """
     Handles and transforms arbitrarily entered events.
     """
@@ -49,10 +50,12 @@ def add_event_param(
                               "transformation to {}").format(accepted_regex,
                                                              template),
                         nargs=nargs,
+                        required=required,
                         type=__event_handler)
 
 
 def add_subject_param(parser: argparse.ArgumentParser,
+                      dest="subject",
                       required: bool = False,
                       choices: List[str] = None) -> None:
     """
@@ -63,15 +66,18 @@ def add_subject_param(parser: argparse.ArgumentParser,
     parser.add_argument("-s", "--study-id", "--subject",
                         help="Subject IDs that the script should affect",
                         nargs=nargs,
+                        dest=dest,
                         choices=choices,
                         # metavar="STUDY_ID"
+                        required=required,
                         action="store")
 
 
 def add_form_param(parser: argparse.ArgumentParser,
+                   dest='forms',
+                   required: bool = False,
                    eligible_forms: List[Tuple[str]] = [],
                    raise_missing: bool = True,
-                   dest='forms',
                    short_switch="-i") -> None:
     """
     Add the forms parameter, with checking for form aliases.
@@ -103,10 +109,12 @@ def add_form_param(parser: argparse.ArgumentParser,
                 raise ValueError("Ambiguous {}, found in following forms: {}"
                                  .format(arg, forms_found))
 
+    nargs = '+' if required else '*'
     parser.add_argument(short_switch, '--forms', '--form', '--instrument',
-                        dest=dest,
-                        nargs='*',
                         help="Forms that the script should affect",
+                        dest=dest,
+                        nargs=nargs,
+                        required=required,
                         type=__form_handler)
 
 

--- a/cli.py
+++ b/cli.py
@@ -30,7 +30,7 @@ def add_event_param(
         required: bool = False,
         template: str = "{}y visit",
         accepted_regex: str = r'^\d+$',
-        coerce: bool = True) -> None:
+        keep_nonmatch: bool = False) -> None:
     """
     Handles and transforms arbitrarily entered events.
     """
@@ -40,7 +40,7 @@ def add_event_param(
     def __event_handler(arg: str) -> Union[str, None]:
         if re.match(accepted_regex, arg):
             return template.format(arg)
-        elif coerce:
+        elif keep_nonmatch:
             return arg
         else:
             return None
@@ -96,6 +96,9 @@ def add_form_param(parser: argparse.ArgumentParser,
     #         _eligible_forms.append(x)
 
     def __form_handler(arg):
+        if len(eligible_forms) == 0:
+            return arg
+
         forms_found = [x for x in eligible_forms if arg in x]
         if len(forms_found) == 1:
             return forms_found[0][0]

--- a/cmds/exec_redcap_locking_data.py
+++ b/cmds/exec_redcap_locking_data.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
     cli.add_event_param(parser, required=True, template="{} visit",
                         # backwards-compatible with the old '4y visit':
-                        accepted_regex=r'^\dy$', keep_nonmatch=True)
+                        accepted_regex=r'^(Baseline|\dy)$', keep_nonmatch=True)
     cli.add_form_param(parser, dest='form', raise_missing=False, required=True,
                        short_switch='-f')
     cli.add_subject_param(parser, dest="subject_id")

--- a/cmds/exec_redcap_locking_data.py
+++ b/cmds/exec_redcap_locking_data.py
@@ -2,9 +2,9 @@
 from __future__ import print_function
 from builtins import str
 import sys
-import argparse 
+import argparse
 import sibispy
-
+from sibispy import cli
 from sibispy import sibislogger as slog
 from sibispy import redcap_locking_data 
 
@@ -99,25 +99,23 @@ if __name__ == "__main__":
     parser.add_argument("-a", "--arm", dest="arm", required=False,
                         choices=['Standard Protocol'], default='Standard Protocol',
                         help="Arm Name as appears in UI")
-    parser.add_argument("-e", "--event", dest="event", required=False, nargs="*",
-                        choices=['Baseline visit', '1y visit', '2y visit', '3y visit','4y visit'],
-                        help="Event Name in as appears in UI", default=['Baseline visit', '1y visit', '2y visit', '3y visit', '4y visit'])
-    parser.add_argument("-f", "--form", dest="form", required=True, nargs="+",
-                        help="Form Name in lowercase_underscore")
+
+    cli.add_event_param(parser, required=True, template="{} visit",
+                        # backwards-compatible with the old '4y visit':
+                        accepted_regex=r'^\dy$', keep_nonmatch=True)
+    cli.add_form_param(parser, dest='form', raise_missing=False, required=True,
+                       short_switch='-f')
+    cli.add_subject_param(parser, dest="subject_id")
+    cli.add_standard_params(parser)  # -v, -p, -t
+
     parser.add_argument("-o", "--outfile", dest="outfile",
                         default='/tmp/locked_records.csv',
                         help="Path to scratch-write current locked records file. {0}".format(default))
-    parser.add_argument("-s", "--subject_id", help="REDCap subject ID(s) (separate with spaces)", nargs="*")
     action_group = parser.add_argument_group('Action parameters', '(Mutually exclusive)')
     action_group_exclusives = action_group.add_mutually_exclusive_group(required=True)
     action_group_exclusives.add_argument("--lock", dest="lock", action="store_true", help="Lock form(s)")
     action_group_exclusives.add_argument("--unlock", dest="unlock", action="store_true", help="Unlock form(s)")
     action_group_exclusives.add_argument("--report", dest="report", action="store_true", help="Generate a report of form lock statuses")
-
-    parser.add_argument("-v", "--verbose", dest="verbose",
-                        help="Turn on verbose", action='store_true')
-    parser.add_argument("-p", "--post-to-github", help="Post all issues to GitHub instead of std out.", action="store_true")
-    parser.add_argument("-t", "--time-log-dir", help="If set then time logs are written to that directory", action="store", default=None)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Useful because we'll need to perform actions on Year 5 forms at some point and until now, we'd have had to add Y5 support (and beyond) in each one.

Closes #34.