### PR TITLE
Only drop demographics rows/columns if they're entirely NA

### DIFF
--- a/redcap_compute_summary_scores.py
+++ b/redcap_compute_summary_scores.py
@@ -84,7 +84,9 @@ class redcap_compute_summary_scores(object):
         except:
             pass
         finally:
-            self.__demographics = self.__demographics.dropna()
+            self.__demographics = (self.__demographics
+                                   .dropna(axis=1, how='all')
+                                   .dropna(axis=0, how='all'))
         
         self.__demographics = pandas.concat([self.__demographics.xs(event, level=1) for event in baseline_events])
 


### PR DESCRIPTION
When demographics fields that only some subjects had were requested,
`redcap_compute_summary_scores` would supply a heavily subsetted
`demographics` because of this logic.

(This PR is a prerequisite for a implementation of sibis-platform/hivalc-operations#28.)