### PR TITLE
Correct issues with midyear report export

### DIFF
--- a/redcap_to_casesdir.py
+++ b/redcap_to_casesdir.py
@@ -358,13 +358,18 @@ class redcap_to_casesdir(object):
             else:
                 family_id = str(int(subject_data['family_id']))
 
+            if conditional:
+                visit_age = ''
+            else:
+                visit_age = self.__truncate_age__(visit_age)
+
             demographics = [
                 ['subject', subject_code],
                 ['arm', arm_code],
                 ['visit', visit_code],
                 ['site', site],
                 ['sex', subject[8]],
-                ['visit_age', self.__truncate_age__(visit_age)],
+                ['visit_age', visit_age],
                 ['mri_structural_age', self.__truncate_age__(visit_data['mri_t1_age'])],
                 ['mri_diffusion_age', self.__truncate_age__(visit_data['mri_dti_age'])],
                 ['mri_restingstate_age', self.__truncate_age__(visit_data['mri_rsfmri_age'])],

--- a/tests/test_redcap_locking_data.py
+++ b/tests/test_redcap_locking_data.py
@@ -70,5 +70,14 @@ assert(not table_df.empty)
 indirect = red_lock.report_locked_forms(test_subject,test_subject, forms, project_name, arm_name, event_name,table_df)
 assert(direct.equals(indirect))
 
+enriched_df = red_lock.report_locked_forms_from_enriched_lock_table(
+    subject_id=test_subject,
+    xnat_id=test_subject,
+    project_name=project_name,
+    forms=forms,
+    redcap_event_name=event_unique,
+    enriched_table=table_df,
+)
+assert(not enriched_df.empty)
 
 

--- a/tests/test_redcap_to_casesdir.py
+++ b/tests/test_redcap_to_casesdir.py
@@ -44,8 +44,22 @@ def test_save_demographics_to_file():
   assert(red2cas.create_demographic_datadict(outdir))
   
   # Note : output writen to file by this function does not necessarily respond to real subject data 
-  assert(red2cas.export_subject_demographics(subject_red_id, subject_xnat_id,arm_code,visit_code, subject_site_id, visit_age , this_subject_data, subject_visit_data, -1, -1, None, outdir))
-  
+  assert(red2cas.export_subject_demographics(
+    subject_red_id,
+    subject_xnat_id,
+    arm_code,
+    visit_code,
+    subject_site_id,
+    visit_age ,
+    this_subject_data,
+    subject_visit_data,
+    -1,
+    -1,
+    None,
+    measures_dir=outdir,
+    conditional=False
+  ))
+
 #=====================================
 def test_save_form_to_file(name_of_form):
 
@@ -94,7 +108,7 @@ if not os.path.exists(outdir) :
 # SUBJECT SPECIFIC INFO 
 #
 
-visit_log_fields = ['study_id', 'visit_date',
+visit_log_fields = ['study_id', 'visit_date', 'family_id',
                       'mri_qa_completed', 'mri_t1_age', 'mri_dti_age',
                       'mri_rsfmri_age','mri_scanner', 'visit_ignore','mri_xnat_sid']
 
@@ -119,7 +133,7 @@ subject_xnat_id =  str(subject_visit_data['mri_xnat_sid'])
 (arm_code,visit_code,subject_datadir_rel) = red2cas.translate_subject_and_event(subject_xnat_id, subject_event_id)
 
 subject_fields = ['study_id', 'dob',  'exclude', 'enroll_exception',
-                  'siblings_enrolled', 'siblings_id1', 'hispanic', 'race','race_other_code']
+                  'siblings_enrolled', 'siblings_id1', 'hispanic', 'race','race_other_code', 'family_id']
 #baseline_events = ['baseline_visit_arm_1','baseline_visit_arm_4']
 #for speed up just the single subject- records flag
 baseline_events = ['baseline_visit_arm_1']


### PR DESCRIPTION
- [x] Lock information exports onto full-year event, without midyear visit notes overwriting full-year visit notes lock status
- [x] Midyear demographics export iff midyear is the only thing for the full-year event