### PR TITLE
Add return job id in schedule_job

### DIFF
--- a/cluster_util.py
+++ b/cluster_util.py
@@ -100,7 +100,7 @@ class ClusterScheduler(ABC):
             if r.stderr and r.stderr != '':
                 slog.info(self._make_bug_title(job_title, r.stderr), "ERROR: Failed to schedule job!",
                           cmd_str=r.command, err_msg=r.stderr)
-                return False
+                return False, -1
 
             if verbose:
                 if r:
@@ -109,7 +109,7 @@ class ClusterScheduler(ABC):
 
         except SSHException as e:
             slog.info(bug_title, "ERROR: Failed to schedule job!", cmd=cmd_str, err_msg=str(e))
-            return False
+            return False, -1
 
         if submit_log:
             with open(submit_log, 'a') as sl:
@@ -119,7 +119,9 @@ class ClusterScheduler(ABC):
                 sl.write(f"STDOUT: {r.stdout}\n")
                 sl.write(f"STDERR: {r.stderr}\n")
 
-        return True
+        job_id = int(r.stdout.split(' ')[-1])
+
+        return True, job_id
 
 
 class SlurmScheduler(ClusterScheduler):

--- a/redcap_to_casesdir.py
+++ b/redcap_to_casesdir.py
@@ -564,7 +564,7 @@ class redcap_to_casesdir(object):
 
         slurm_config = self.__sibis_defs['cluster_config']
         slurm = SlurmScheduler(slurm_config)
-        return slurm.schedule_job(job_script, job_title, submit_log, job_log, verbose)
+        return slurm.schedule_job(job_script, job_title, submit_log, job_log, verbose)[0]
 
     def schedule_old_cluster_job(self,job_script, job_title,submit_log=None, job_log=None, verbose=False):
         qsub_cmd= '/opt/sge/bin/lx-amd64/qsub'

--- a/tests/test_cluster_util.py
+++ b/tests/test_cluster_util.py
@@ -135,7 +135,7 @@ def test_slurm_schedule_job(capsys, monkeypatch, request, session, test_config, 
     slurm = SlurmScheduler(test_config['cluster_config'])
     with capsys.disabled():
         monkeypatch.setattr('sys.stdin', open('/dev/null'))
-        scheduled = slurm.schedule_job(cmd_str, request.module.__name__, cluster_submit_log, cluster_job_log, True)
+        scheduled, _ = slurm.schedule_job(cmd_str, request.module.__name__, cluster_submit_log, cluster_job_log, True)
         assert scheduled, "Cluster Job should have been scheduled"
 
     print(f"Please check {cluster_job_log} if cluster job was successfully executed !")


### PR DESCRIPTION
WHAT: Modify the return value to include job id of the submitted Slurm job. Also modify related files which use ClusterScheduler::schedule_job function.
TEST: Use pipeline-hivalc:test which is the image containing sibispy of this branch to run job_submission_dag. 