### PR TITLE
Append to log file and not truncate

### DIFF
--- a/cluster_util.py
+++ b/cluster_util.py
@@ -132,7 +132,8 @@ class SlurmScheduler(ClusterScheduler):
         slurm_opts = {
             "--job-name": f"'{job_title}'",
             "--output": job_log,
-            "--wrap": f"'{job_script}'"
+            "--wrap": f"'{job_script}'",
+            "--open-mode": "append"
         }
 
         base_cmd = self.config['base_cmd']


### PR DESCRIPTION
When submitting jobs via slurm add `--open-mode=append` flag to make sure we append and not truncate log files.