### PR TITLE
Bug/kill selenium process

### DIFF
--- a/session.py
+++ b/session.py
@@ -220,7 +220,7 @@ class Session(object):
 
     def __list_running_process__(self,cmd): 
         from subprocess import Popen, PIPE
-        check_cmd  = "ps -ef | grep '" + cmd + "' | awk '{print $2}'"
+        check_cmd  = "ps -efww | grep '" + cmd + "' | awk '{print $2}'"
 
         try : 
             p = Popen(check_cmd, shell = True, stdout = PIPE,  stderr = PIPE)

--- a/session.py
+++ b/session.py
@@ -232,7 +232,6 @@ class Session(object):
         
     @contextmanager
     def __connect_penncnp__(self):
-        import pdb;pdb.set_trace()
         # Check that config file is correctly defined 
         if "penncnp" not in list(self.__config_srv_data.keys()):
             slog.info("session.__connnect_penncnp__","ERROR: penncnp server info not defined!")
@@ -744,12 +743,13 @@ class Session(object):
 
         if "DISPLAY" in list(os.environ.keys()) and  os.environ['DISPLAY'] == self.api['browser_penncnp']['display'] :
             del os.environ['DISPLAY']
- 
+
         import subprocess
         kill_cmd = "kill -9 " + str(self.api['browser_penncnp']['pip']) 
         try:
             err_msg = subprocess.check_output(kill_cmd,shell=True)
-        except Exception as err_msg:
+        except Exception as e:
+            err_msg = e
             pass
             
         

--- a/session.py
+++ b/session.py
@@ -232,6 +232,7 @@ class Session(object):
         
     @contextmanager
     def __connect_penncnp__(self):
+        import pdb;pdb.set_trace()
         # Check that config file is correctly defined 
         if "penncnp" not in list(self.__config_srv_data.keys()):
             slog.info("session.__connnect_penncnp__","ERROR: penncnp server info not defined!")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -301,11 +301,12 @@ def test_session_browser_penncnp(slog, config_file, session, config_test_data, p
         wait = session.initialize_penncnp_wait()
         assert session.get_penncnp_export_report(wait), "Error: could not export report."
 
-def test_stale_penncnp(slog, config_file, session, config_test_data, penncnp_cleanup):
+def test_penncnp_exits(slog, config_file, session, config_test_data, penncnp_cleanup):
     project = 'browser_penncnp'
     with session.connect_server(project, True) as server:
-        with session.connect_server(project, True) as server2:
-            assert server2 != None, "Error: could not create second server"
+        pass
+    with session.connect_server(project, True) as server2:
+        assert server2 != None, "Error: could not connect second server! Make sure the selenium process exits correctly."
 
 def test_session_legacy(config_file, special_opts):
     import os

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -295,14 +295,17 @@ def penncnp_cleanup(session):
 
 def test_session_browser_penncnp(slog, config_file, session, config_test_data, penncnp_cleanup):
     project = 'browser_penncnp'
-    # import pdb; pdb.set_trace()
-    server = session.connect_server(project, True)
+    with session.connect_server(project, True) as server:
+        assert server != None, "Error: could not connect server! Make sure " + project + " is correctly defined in " + config_file
 
-    assert server != None, "Error: could not connect server! Make sure " + project + " is correctly defined in " + config_file
+        wait = session.initialize_penncnp_wait()
+        assert session.get_penncnp_export_report(wait), "Error: could not export report."
 
-    wait = session.initialize_penncnp_wait()
-    assert session.get_penncnp_export_report(wait)
-
+def test_stale_penncnp(slog, config_file, session, config_test_data, penncnp_cleanup):
+    project = 'browser_penncnp'
+    with session.connect_server(project, True) as server:
+        with session.connect_server(project, True) as server2:
+            assert server2 != None, "Error: could not create second server"
 
 def test_session_legacy(config_file, special_opts):
     import os


### PR DESCRIPTION
I fixed the test_session_browser_penncnp test to account for the fact that connect_penncnp returns a generator. I also changed the list_running_process command so that it doesn't truncate the command names [this was causing existing selenium processes to not be detected].
I discovered that there is already a function, disconnect_penncnp, which kills the selenium process. I fixed the way that this function reports errors when calling kill, but this shouldn't affect the unkilled process problem. This function is called when the penncnp browser object goes out of scope. When I added a test_stale_penncnp test which makes two penncnp sessions, the test passed, suggesting that disconnect_penncnp is correctly called. When I wrote a version of this test to open a second session while the other session is still in scope, the "Error: sessions with display " + display + " are already \
running ! Please execute 'kill -9 "" error _did_ arise, as you would expect, but this is clearly not the cause of the  get_results_selenium errors.
In conclusion: I'm not sure why the get_results_selenium error arose. This PR just fixes the tests.