### PR TITLE
Add ability to override hard coded dirs like `cases`

### DIFF
--- a/cmds/run_all_tests
+++ b/cmds/run_all_tests
@@ -5,7 +5,7 @@ TEST_DIR=`cd $SRC_DIR; echo $PWD | rev | cut -d'/' -f2- | rev`/tests
 
 CFG_FILE=~/.sibis-general-config.yml 
 LEGACY_TESTS=(test_utils.py test_config_file_parser.py test_redcap_to_casesdir.py test_redcap_locking_data.py test_redcap_compute_summary_scores.py)
-MODERN_TESTS=(test_post_issues_to_github.py test_sibislogger.py test_xnat_util.py test_session.py test_sibis_svn_util.py test_sibis_email.py test_check_dti_gradients.py)
+MODERN_TESTS=(test_post_issues_to_github.py test_sibislogger.py test_xnat_util.py test_session_valuedictkey.py test_session.py test_sibis_svn_util.py test_sibis_email.py test_check_dti_gradients.py)
 
 logFile=`mktemp`
 for TEST in ${MODERN_TESTS[@]}; do  

--- a/config_file_parser.py
+++ b/config_file_parser.py
@@ -84,6 +84,13 @@ class config_file_parser(object):
 
         return self.__config_dict.get(category)
 
+
+    def has_category(self,category):
+        if not self.__config_dict:
+            raise RuntimeError("Please run configure first before calling this function!")
+        
+        return category in self.__config_dict
+
     def keys(self):
         if not self.__config_dict :
             raise RuntimeError("Please run configure first before calling this function!")

--- a/session.py
+++ b/session.py
@@ -91,6 +91,29 @@ class CapturingTee(list):
         sys.stdout = self._stdout
     
 
+class ValueKeyDict(dict):
+    def __getitem__(self, index):
+        val = super().__getitem__(index)
+        if val == None:
+            return index
+        else:
+            return val
+
+SIBIS_DIRS = ValueKeyDict({
+    "beta": None,
+    "log": None,
+    "operations": None,
+    "cases": None,
+    "summaries": None,
+    "burn2dvd": None,
+    "datadict": None,
+    "laptops": None,
+    "laptops_svn": "ncanda",
+    "laptops_imported": "imported",
+    "XNAT": None,
+    "redcap": None
+})
+
 
 # --------------------------------------------
 # CLASS DEFINITION
@@ -144,7 +167,11 @@ class Session(object):
         if err_msg :
             slog.info('session.configure',str(err_msg))
             return False
-            
+        
+        if sys_file_parser.has_category('sibis_dirs'):
+            sibis_dirs = sys_file_parser.get_category('sibis_dirs')
+            SIBIS_DIRS.update(sibis_dirs)
+
         self.__config_srv_data = sys_file_parser.get_category('session')
 
         return True
@@ -436,19 +463,19 @@ class Session(object):
     def get_beta_dir(self):
         aDir = self.__get_analysis_dir()
         if aDir :
-            return os.path.join(aDir,'beta')
+            return os.path.join(aDir,SIBIS_DIRS['beta'])
         return None
 
     def get_log_dir(self):
         aDir = self.__get_analysis_dir()
         if aDir :
-            return os.path.join(aDir,'log')
+            return os.path.join(aDir,SIBIS_DIRS['log'])
         return None
 
     def get_operations_dir(self):
         aDir = self.__get_analysis_dir()
         if aDir :
-            return os.path.join(aDir,'operations')
+            return os.path.join(aDir,SIBIS_DIRS['operations'])
         return None
 
     def get_config_parser_for_file(self, key, filename):
@@ -477,44 +504,44 @@ class Session(object):
     def get_cases_dir(self):
         aDir = self.__get_analysis_dir()
         if aDir :
-            return os.path.join(aDir,'cases')
+            return os.path.join(aDir,SIBIS_DIRS['cases'])
         return None
 
     def get_summaries_dir(self):
         aDir = self.__get_analysis_dir()
         if aDir :
-            return os.path.join(aDir,'summaries')
+            return os.path.join(aDir,SIBIS_DIRS['summaries'])
         return None
 
     def get_dvd_dir(self):
         aDir = self.__get_analysis_dir()
         if aDir :
-            return os.path.join(aDir,'burn2dvd')
+            return os.path.join(aDir,SIBIS_DIRS['burn2dvd'])
         return None
 
     def get_datadict_dir(self):
         aDir = self.__get_analysis_dir()
         if aDir :
-            return os.path.join(aDir,'datadict')
+            return os.path.join(aDir,SIBIS_DIRS['datadict'])
         return None
 
 
     def __get_laptop_dir(self):
-        return os.path.join(self.__config_usr_data.get_value('import_dir'),'laptops')
+        return os.path.join(self.__config_usr_data.get_value('import_dir'),SIBIS_DIRS['laptops'])
 
     # Kilian: Ommit ncanda from svn dir name 
     def get_laptop_svn_dir(self):
-        return os.path.join(self.__get_laptop_dir(),'ncanda')
+        return os.path.join(self.__get_laptop_dir(),SIBIS_DIRS['laptops_svn'])
 
     def get_laptop_imported_dir(self):
-        return os.path.join(self.__get_laptop_dir(),'imported')
+        return os.path.join(self.__get_laptop_dir(),SIBIS_DIRS['laptops_imported'])
 
     def get_xnat_dir(self):
-        return os.path.join(self.__config_usr_data.get_value('import_dir'),'XNAT')
+        return os.path.join(self.__config_usr_data.get_value('import_dir'),SIBIS_DIRS['XNAT'])
 
     # Important for redcap front end - not sibis programs
     def get_redcap_uploads_dir(self):
-        return os.path.join(self.__config_usr_data.get_value('import_dir'),'redcap')
+        return os.path.join(self.__config_usr_data.get_value('import_dir'),SIBIS_DIRS['redcap'])
 
     def get_xnat_server_address(self):
         return self.__config_usr_data.get_value('xnat','server')

--- a/session.py
+++ b/session.py
@@ -92,6 +92,24 @@ class CapturingTee(list):
     
 
 class ValueKeyDict(dict):
+    '''
+    Creates a `dict` with custom indexing behavior where when the requested index
+    value is `None`, the index key is returned.
+    
+    Example:
+    > foo = ValueKeyDict({
+    >     "alpha": None,
+    >     "beta": "charlie"
+    > })
+    > foo.get("alpha") == None
+    True
+    > foo.get("beta") == "charlie"
+    True
+    > foo["alpha"] == "alpha"
+    True
+    > foo["beta"] == "charlie"
+    True
+    '''
     def __getitem__(self, index):
         val = super().__getitem__(index)
         if val == None:

--- a/session.py
+++ b/session.py
@@ -748,10 +748,9 @@ class Session(object):
         kill_cmd = "kill -9 " + str(self.api['browser_penncnp']['pip']) 
         try:
             err_msg = subprocess.check_output(kill_cmd,shell=True)
-        except Exception as err_msg:
-            pass
-            
-        
+        except Exception as err:
+            err_msg = err
+
         if err_msg: 
             slog.info("session.__connect_penncnp__","The following command failed %s with the following output %s" % (kill_cmd,str(err_msg)))
             return None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -295,13 +295,12 @@ def penncnp_cleanup(session):
 
 def test_session_browser_penncnp(slog, config_file, session, config_test_data, penncnp_cleanup):
     project = 'browser_penncnp'
-    # import pdb; pdb.set_trace()
-    server = session.connect_server(project, True)
+    with session.connect_server(project, True) as server:
 
-    assert server != None, "Error: could not connect server! Make sure " + project + " is correctly defined in " + config_file
+        assert server != None, "Error: could not connect server! Make sure " + project + " is correctly defined in " + config_file
 
-    wait = session.initialize_penncnp_wait()
-    assert session.get_penncnp_export_report(wait)
+        wait = session.initialize_penncnp_wait()
+        assert session.get_penncnp_export_report(wait)
 
 
 def test_session_legacy(config_file, special_opts):

--- a/tests/test_session_valuedictkey.py
+++ b/tests/test_session_valuedictkey.py
@@ -1,0 +1,36 @@
+import pytest
+
+def test_valuekeydict():
+    from sibispy.session import ValueKeyDict
+    original =ValueKeyDict({
+        "alpha": None,
+        "beta": "charlie",
+        "delta": "echo"
+    })
+
+    assert len(original.keys()) == 3, "Should be 3 keys"
+    assert original.get("alpha") == None, "Should be None"
+    assert original["alpha"] == "alpha", "Shold be alpha"
+    assert original.get("beta") == "charlie", "Should be charlie"
+    assert original["beta"] == "charlie", "Should be charlie"
+    assert original.get("delta") == "echo", "Should be echo"
+    assert original["delta"] == "echo", "Should be echo"
+
+    original.update({
+        "alpha": "foxtrot",
+        "beta": None,
+        "golf": None,
+        "hotel": "india"
+    })
+
+    assert len(original.keys()) == 5, "Should be 5 keys"
+    assert original.get("alpha") == "foxtrot", "Should be foxtrot"
+    assert original["alpha"] == "foxtrot", "Shold be foxtrot"
+    assert original.get("beta") == None, "Should be None"
+    assert original["beta"] == "beta", "Should be beta"
+    assert original.get("delta") == "echo", "Should be echo"
+    assert original["delta"] == "echo", "Should be echo"
+    assert original.get("golf") == None, "Should be None"
+    assert original["golf"] == "golf", "Should be golf"
+    assert original.get("hotel") == "india", "Should be india"
+    assert original["hotel"] == "india", "Should be india"


### PR DESCRIPTION
We needed a way to specify alternate directory names for the `cases` dir, such as `cases_next`, however the session is hard coded return a specific value.

This change allows redefinition of the following dirs:
```
SIBIS_DIRS = ValueKeyDict({
    "beta": None,
    "log": None,
    "operations": None,
    "cases": None,
    "summaries": None,
    "burn2dvd": None,
    "datadict": None,
    "laptops": None,
    "laptops_svn": "ncanda",
    "laptops_imported": "imported",
    "XNAT": None,
    "redcap": None
})
```
using a customized `dict` that returns the item key if the item value is `None` when accessing via the index operand, i.e. `SIBIS_DIRS['cases'] == 'cases'`.

The project may define an override category in `sibis_sys_config.yaml` as follows:

```
sibis_dirs:
    cases: cases_next
```

Where the above setting will redefine `cases` as `cases_next`.

Unit tests were added to verify functionality:
- `test_session_valuedictkey.py` - this validates that the custom dict works
- `test_session.py` - existing tests already validated correct directory structure.   

Additionally this PR includes an unrelated, but necessary fix as it blocked testing of the new functionality:
- `test_session.py` - fixed so that penncnp test works according to the updated implementation by @shippy approximately a year ago.
-  `session.py` - fixed a scope bug where if the penncnp connection failed, the error message variable goes out of scope and is undefined.