### PR TITLE
Added function to make formattable url

### DIFF
--- a/session.py
+++ b/session.py
@@ -976,6 +976,19 @@ class Session(object):
     def get_redcap_server_address(self):
         return self.__config_usr_data.get_value("redcap", "server")
 
+    def get_redcap_base_address(self):
+        return self.__config_usr_data.get_value("redcap", "base_url")
+
+    def get_formattable_redcap_address(self, project_id: int):
+        # Returns a formattable redcap link for the passed project_id
+        # E.g. for Imported From Laptops, returns https://ncanda.sri.com/redcap/redcap_v10.0.30/DataEntry/index.php?pid=6&id=%s&event_id=%s&page=%s
+        # The three %s's are for the subject_id, event_id, and form_name, respectively
+        # To get formatted address, do formattable_address % (subject_id, event_id, form_name)
+        base_address = self.get_redcap_base_address()
+        version = str(self.get_redcap_version())
+        formattable_address = base_address + f"redcap_v{version}/DataEntry/index.php?pid={project_id}&id=%s&event_id=%s&page=%s"
+        return formattable_address
+    
     #
     # REDCAP API CALLS
     #


### PR DESCRIPTION
Not convinced this is the best way of doing things. We'll still have to get the project_id from the redcap project object, but that object was not written by us so I couldn't add this function to that object and just reference the project_id as an instance variable.

I'm also unsure about returning a formattable string. It might be better to pass in the subject_id, event_id, and form_name to this function and just return the final url. But that would require maintaining access to the session and project objects until these three variables are available in the script. It seems cleaner to just generate what we can as soon as the project object is created, then format this string where we need it. 

Finally, when it comes to actually formatting the string, I'm not sure how to get the integer event id from the string event id for a particular project and arm. 