### PR TITLE
Bug/redcap_address_other_arms

### DIFF
--- a/session.py
+++ b/session.py
@@ -989,7 +989,7 @@ class Session(object):
     def get_redcap_base_address(self):
         return self.__config_usr_data.get_value("redcap", "base_address")
 
-    def get_event_descrip_from_redcap_event_name(self, redcap_event_name:str):
+    def get_event_descrip_from_redcap_event_name(self, redcap_event_name: str):
         if redcap_event_name == "submission_4_inper_arm_6":
             return "Submission 4 In-person"
         visit_regex = "(recovery_baseline)|(recovery_daily_\d*)|(recovery_weekly_\d)|(recovery_final)|(baseline_night_\d)|(\d*y_visit_night_\d)|(\d*y_visit)|(baseline_visit)|(\d*month_followup)|(submission_\d)"
@@ -997,24 +997,24 @@ class Session(object):
         if visit_match is None:
             raise ValueError(f"No matching visit for {redcap_event_name}")
         visit = visit_match.group()
-        
+
         month_match = re.match("(\d*)month_followup", visit)
         if month_match:
-            visit = month_match.group(1) # '66month_followup' -> '66'
-            event_descrip = visit + "-month follow-up" # -> "66-month follow-up'
+            visit = month_match.group(1)  # '66month_followup' -> '66'
+            event_descrip = visit + "-month follow-up"  # -> "66-month follow-up'
             return event_descrip
 
         yearly_standard_match = re.match("(\d*y)_visit", visit)
         if yearly_standard_match:
-            visit = yearly_standard_match.group(1) # '7y_visit' -> '7y'
-            event_descrip = visit + " visit" # -> '7y visit'
+            visit = yearly_standard_match.group(1)  # '7y_visit' -> '7y'
+            event_descrip = visit + " visit"  # -> '7y visit'
             return event_descrip
 
         visit_words = visit.split("_")
         visit_words = [x.capitalize() for x in visit_words]
         event_descrip = " ".join(visit_words)
         return event_descrip
-        
+
     def get_formattable_redcap_form_address(
         self,
         project_id: int,
@@ -1029,14 +1029,14 @@ class Session(object):
         # subject_id: e.g. B-00002-F-2
         # name_of_form: e.g. stroop
         # To replace formatted args, do formattable_address % (subject_id, form_name)
-        arm_match = re.search('arm_(\d*)', redcap_event_name)
+        arm_match = re.search("arm_(\d*)", redcap_event_name)
         if arm_match is None:
             raise ValueError(f"No arm for {redcap_event_name}")
         arm_num = int(arm_match.group(1))
 
         event_descrip = self.get_event_descrip_from_redcap_event_name(redcap_event_name)
 
-        self.connect_server('redcap_mysql_db', True)
+        self.connect_server("redcap_mysql_db", True)
         arm_id = self.get_mysql_arm_id_from_arm_num(arm_num, project_id)
         event_id = self.get_mysql_event_id(event_descrip, arm_id)
 
@@ -1053,10 +1053,9 @@ class Session(object):
         )
         return formattable_address
 
-    def get_formattable_redcap_subject_address(self,
-                                       project_id: int,
-                                       arm_num: int,
-                                       subject_id=None):
+    def get_formattable_redcap_subject_address(
+        self, project_id: int, arm_num: int, subject_id=None
+    ):
         # Returns a possibly formattable redcap link for the passed arguments, 2 mandatory:
         # project_name: see table in https://neuro.sri.com/labwiki/index.php?title=Locking_in_REDCap
         # arm_num: e.g. 1
@@ -1401,7 +1400,6 @@ class Session(object):
         ].arm_id
         return int(arm_id)
 
-    
     def get_mysql_event_id(self, event_descrip, arm_id):
         """
         Get an event_id using the event description and arm_id

--- a/session.py
+++ b/session.py
@@ -988,31 +988,50 @@ class Session(object):
     def get_redcap_base_address(self):
         return self.__config_usr_data.get_value("redcap", "base_address")
 
+    def get_event_descrip_from_redcap_event_name(self, redcap_event_name:str):
+        visit_regex = "(recovery_baseline)|(recovery_daily_\d*)|(recovery_weekly_\d)|(recovery_final)|(baseline_night_\d)|(\d*y_visit_night_\d)|(\d*y_visit)|(baseline_visit)|(\d*month_followup)|(submission_\d)"
+        visit_match = re.match(visit_regex, redcap_event_name)
+        if visit_match is None:
+            raise ValueError(f"No matching visit for {redcap_event_name}")
+        visit = visit_match.group()
+
+        month_match = re.match("(\d*)month_followup", visit)
+        if month_match
+            visit = month_match.group(1) # '66month_followup' -> '66'
+            event_descrip = visit + "-month follow-up" # -> "66-month follow-up'
+            return event_descrip
+
+        yearly_standard_match = re.match("(\d*y)_visit_arm", visit)
+        if yearly_standard_match:
+            visit = yearly_standard_match.group(1) # '7y_visit' -> '7y'
+            event_descrip = visit + " visit" # -> '7y visit'
+            return event_descrip
+
+        visit_words = visit.split("_")
+        visit_words = [x.capitalize() for x in visit_words]
+        event_descrip = " ".join(visit_words)
+        return event_descrip
+        
     def get_formattable_redcap_form_address(
         self,
         project_id: int,
-        visit: str,
-        arm_num: int,
+        redcap_event_name: str,
         subject_id=None,
         name_of_form=None,
     ):
         # Returns a possibly formattable redcap link for the passed arguments, 3 mandatory:
         # project_name: see table in https://neuro.sri.com/labwiki/index.php?title=Locking_in_REDCap
-        # visit: e.g. 7y_visit or 66month_followup
-        # arm_num: e.g. 1
+        # redcap_event_name: e.g. 7y_visit_arm_1 or recovery_daily_29_arm_2
         # And 2 optional (if not passed, they will be replaced by the %s placeholder which can be replaced later with the real value):
         # subject_id: e.g. B-00002-F-2
         # name_of_form: e.g. stroop
         # To replace formatted args, do formattable_address % (subject_id, form_name)
+        arm_match = re.search('arm_(\d*)', redcap_event_name)
+        if arm_match is None:
+            raise ValueError(f"No arm for {redcap_event_name}")
+        arm_num = int(arm_match.group(1))
 
-        if "month" in visit:
-            visit = visit.split("month_followup")[0] # '66month_followup' -> '66'
-            event_descrip = visit + "-month follow-up" # -> "66-month follow-up'
-        else:
-            visit = visit.split("_")[0] # '7y_visit' -> '7y'
-            if visit == 'baseline':
-                visit = 'Baseline'
-            event_descrip = visit + " visit" # -> '7y visit'
+        event_descrip = get_event_descrip_from_redcap_event_name(redcap_event_name)
 
         self.connect_server('redcap_mysql_db', True)
         arm_id = self.get_mysql_arm_id_from_arm_num(arm_num, project_id)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -407,32 +407,37 @@ def test_session_xnat_search(slog, config_file, session, config_test_data):
     )
     assert subject_project_list != None, "Search result should not be None."
 
+
 def test_session_event_descrip_from_redcap_event_name(slog, session):
     session.connect_server("data_entry", True)
-    session.connect_server('redcap_mysql_db', True)
+    session.connect_server("redcap_mysql_db", True)
     event_descrips = pd.read_sql_table(
-            "redcap_events_metadata", session.api["redcap_mysql_db"]
-        )['descrip'].to_list()
+        "redcap_events_metadata", session.api["redcap_mysql_db"]
+    )["descrip"].to_list()
 
     entry_data = session.redcap_export_records_from_api(
         time_label=None,
         api_type="data_entry",
-        fields=['study_id'],
+        fields=["study_id"],
         event_name="unique",
         format="df",
         export_data_access_groups=False,
     ).reset_index()
-    redcap_event_names = entry_data['redcap_event_name'].to_list()
+    redcap_event_names = entry_data["redcap_event_name"].to_list()
     for redcap_event_name in redcap_event_names:
-        event_descrip = session.get_event_descrip_from_redcap_event_name(redcap_event_name)
-        assert event_descrip in event_descrips, f"{event_descrip} incorrect event descrip for {redcap_event_name}"
-    
-    
+        event_descrip = session.get_event_descrip_from_redcap_event_name(
+            redcap_event_name
+        )
+        assert (
+            event_descrip in event_descrips
+        ), f"{event_descrip} incorrect event descrip for {redcap_event_name}"
+
+
 def test_session_formattable_redcap_form_address(slog, session):
     session.configure(ordered_config_load_flag=True)
     redcap_project = session.connect_server("data_entry", True)
     assert redcap_project, "Failed to connect to data_entry"
-    project_id = redcap_project.export_project_info()['project_id']
+    project_id = redcap_project.export_project_info()["project_id"]
     arm_num = 1
     visit = "7y_visit"
     redcap_event_name = f"{visit}_arm_{arm_num}"
@@ -443,7 +448,9 @@ def test_session_formattable_redcap_form_address(slog, session):
     test_link = f"{session.get_redcap_base_address()}redcap_v{version}/DataEntry/index.php?pid={project_id}&id={subject_id}&event_id={event_id}&page={form_name}"
 
     # Test formatting when passing neither subject_id nor form_name
-    formattable_address = session.get_formattable_redcap_form_address(project_id, redcap_event_name)
+    formattable_address = session.get_formattable_redcap_form_address(
+        project_id, redcap_event_name
+    )
     formatted_address = formattable_address % (subject_id, form_name)
     assert formatted_address == test_link
 
@@ -466,7 +473,6 @@ def test_session_formattable_redcap_form_address(slog, session):
         project_id, redcap_event_name, subject_id, form_name
     )
     assert complete_address == test_link
-
 
 
 def test_session_formattable_redcap_subject_address(slog, session):


### PR DESCRIPTION
The old form link util assumed the visit was from the standard arm, and made the client parse the redcap_event_name. Now the client can pass in arbitrary redcap_event_names. Necessary to fix [this](https://github.com/sibis-platform/ncanda-data-integration/issues/494) issue.
Also added a test for the redcap_event_name to event_descrip function and modified the old test.
Test outputs:
```
ncanda@pipeline-back[pipeline_back_1]:/fs/ncanda-share/log/make_all_inventories/reports$ pytest /fs/ncanda-share/beta/griffin/sibispy/tests/test_session.py -k "test_session_formattable_redcap_form_address or test_session_event_descrip_from_redcap_event_name"
======================== test session starts =========================
platform linux -- Python 3.8.7, pytest-7.1.1, pluggy-1.0.0
cachedir: /home/ncanda/.pytest_cache
rootdir: /fs/ncanda-share/beta/griffin/sibispy/tests, configfile: pytest.ini
plugins: snapshot-0.5.0, mock-3.5.1, shutil-1.4.0, anyio-3.5.0, svn-1.4.0
collected 19 items / 17 deselected / 2 selected                      

../../../beta/griffin/sibispy/tests/test_session.py ..         [100%]

========================== warnings summary ==========================
../../../../../usr/local/lib/python3.8/site-packages/future/standard_library/__init__.py:65
  /usr/local/lib/python3.8/site-packages/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

../../../../../usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:10
  /usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:10: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _nlv = LooseVersion(_np_version)

../../../../../usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:11
  /usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:11: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p16 = _nlv < LooseVersion("1.16")

../../../../../usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:12
  /usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:12: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p17 = _nlv < LooseVersion("1.17")

../../../../../usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:13
  /usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:13: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p18 = _nlv < LooseVersion("1.18")

../../../../../usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:14
  /usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:14: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p19 = _nlv < LooseVersion("1.19")

../../../../../usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:15
  /usr/local/lib/python3.8/site-packages/pandas/compat/numpy/__init__.py:15: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_under1p20 = _nlv < LooseVersion("1.20")

../../../../../usr/local/lib/python3.8/site-packages/setuptools/_distutils/version.py:351
  /usr/local/lib/python3.8/site-packages/setuptools/_distutils/version.py:351: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    other = LooseVersion(other)

../../../../../usr/local/lib/python3.8/site-packages/pandas/compat/numpy/function.py:125
../../../../../usr/local/lib/python3.8/site-packages/pandas/compat/numpy/function.py:125
  /usr/local/lib/python3.8/site-packages/pandas/compat/numpy/function.py:125: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(_np_version) >= LooseVersion("1.17.0"):

../../../../../usr/local/lib/python3.8/site-packages/yaml/constructor.py:126
  /usr/local/lib/python3.8/site-packages/yaml/constructor.py:126: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    if not isinstance(key, collections.Hashable):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 2 passed, 17 deselected, 11 warnings in 3.81s ============
```